### PR TITLE
Fix: chart releaser tags

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -83,25 +83,23 @@ jobs:
 
       - name: Chart releaser
         run: |
-          # donwload helm chart releaser
+          # Download chart releaser
           curl -sSLo cr.tar.gz "https://github.com/helm/chart-releaser/releases/download/v1.2.1/chart-releaser_1.2.1_linux_amd64.tar.gz"
           tar -xzf cr.tar.gz
           rm -f cr.tar.gz
           repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
-            owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
+          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
           exists=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/konstellation-io/$repo/releases/tags/$repo-${{ steps.fix_tag.outputs.tag }} -w %{http_code} -o /dev/null)
           if [[ $exists != "200" ]]; then
             echo "Creating release..."
             # package chart
-            ./cr package ${{ inputs.chart_path }}
-            # upload chart to github relases
+            ./cr package ${{ inputs.chart_path }}/$repo
+            # upload chart to github releases
             ./cr upload \
                 --owner "$owner" \
                 --git-repo "$repo" \
                 --token "${{ secrets.GITHUB_TOKEN }}"
-            # update index and push to github pages
-            git config user.email "$owner@users.noreply.github.com"
-            git config user.name "$owner"
+            # Update index and push to github pages
             ./cr index \
                 --owner "$owner" \
                 --git-repo "$repo" \

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -81,10 +81,33 @@ jobs:
             helm repo add $NAME $REPO
           done
 
-      - name: Generate chart release
-        uses: helm/chart-releaser-action@v1.2.1
-        with:
-          charts_dir: ${{ inputs.chart_path }}
-          charts_repo_url: ${{ inputs.chart_url }}
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Chart releaser
+        run: |
+          # donwload helm chart releaser
+          curl -sSLo cr.tar.gz "https://github.com/helm/chart-releaser/releases/download/v1.2.1/chart-releaser_1.2.1_linux_amd64.tar.gz"
+          tar -xzf cr.tar.gz
+          rm -f cr.tar.gz
+          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+            owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
+          exists=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/konstellation-io/$repo/releases/tags/$repo-${{ steps.fix_tag.outputs.tag }} -w %{http_code} -o /dev/null)
+          if [[ $exists != "200" ]]; then
+            echo "Creating release..."
+            # package chart
+            ./cr package ${{ inputs.chart_path }}
+            # upload chart to github relases
+            ./cr upload \
+                --owner "$owner" \
+                --git-repo "$repo" \
+                --token "${{ secrets.GITHUB_TOKEN }}"
+            # update index and push to github pages
+            git config user.email "$owner@users.noreply.github.com"
+            git config user.name "$owner"
+            ./cr index \
+                --owner "$owner" \
+                --git-repo "$repo" \
+                --token "${{ secrets.GITHUB_TOKEN }}" \
+                --charts-repo ${{ inputs.chart_url }} \
+                --push
+          else
+            echo "Release already exists"
+          fi


### PR DESCRIPTION
`Chart Releaser` action doesn't generate a release on tags, only on branches, so we need to have a workaround to run directly on tags when a fix it's needed.