### PR TITLE
fix: Use new chart releaser action

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -71,7 +71,6 @@ jobs:
       - name: Chart releaser 
         uses: stefanprodan/helm-gh-pages@v1.4.1
         with:
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
           charts_dir: ${{ inputs.chart_path }}
           charts_url: ${{ inputs.chart_url }}
           linting: "off"

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -68,44 +68,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.pat }}
 
-      - uses: azure/setup-helm@v1
-
-      - uses: chrisdickinson/setup-yq@latest
-
-      - name: Add repos
-        run: |
-          for i in $(yq r ct.yaml 'chart-repos'| sed -e 's/^- //')
-          do
-            NAME=$(echo $i | awk -F"=" '{print $1}')
-            REPO=$(echo $i | awk -F"=" '{print $2}')
-            helm repo add $NAME $REPO
-          done
-
-      - name: Chart releaser
-        run: |
-          # Download chart releaser
-          curl -sSLo cr.tar.gz "https://github.com/helm/chart-releaser/releases/download/v1.2.1/chart-releaser_1.2.1_linux_amd64.tar.gz"
-          tar -xzf cr.tar.gz
-          rm -f cr.tar.gz
-          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
-          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
-          exists=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/konstellation-io/$repo/releases/tags/$repo-${{ steps.fix_tag.outputs.tag }} -w %{http_code} -o /dev/null)
-          if [[ $exists != "200" ]]; then
-            echo "Creating release..."
-            # package chart
-            ./cr package ${{ inputs.chart_path }}/$repo
-            # upload chart to github releases
-            ./cr upload \
-                --owner "$owner" \
-                --git-repo "$repo" \
-                --token "${{ secrets.GITHUB_TOKEN }}"
-            # Update index and push to github pages
-            ./cr index \
-                --owner "$owner" \
-                --git-repo "$repo" \
-                --token "${{ secrets.GITHUB_TOKEN }}" \
-                --charts-repo ${{ inputs.chart_url }} \
-                --push
-          else
-            echo "Release already exists"
-          fi
+      - name: Chart releaser 
+        uses: stefanprodan/helm-gh-pages@v1.4.1
+        with:
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          charts_dir: ${{ inputs.chart_path }}
+          charts_url: ${{ inputs.chart_url }}
+          linting: "off"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/new-release.yaml
+++ b/.github/workflows/new-release.yaml
@@ -62,7 +62,6 @@ jobs:
       - name: Chart releaser 
         uses: stefanprodan/helm-gh-pages@v1.4.1
         with:
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
           charts_dir: ${{ inputs.chart_path }}
           charts_url: ${{ inputs.chart_url }}
           linting: "off"

--- a/.github/workflows/new-release.yaml
+++ b/.github/workflows/new-release.yaml
@@ -59,23 +59,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.pat }}
       
-      - uses: azure/setup-helm@v1
-
-      - uses: chrisdickinson/setup-yq@latest
-
-      - name: Add repos
-        run: |
-          for i in $(yq r ct.yaml 'chart-repos'| sed -e 's/^- //')
-          do
-            NAME=$(echo $i | awk -F"=" '{print $1}')
-            REPO=$(echo $i | awk -F"=" '{print $2}')
-            helm repo add $NAME $REPO
-          done
-      
-      - name: Generate chart release
-        uses: helm/chart-releaser-action@v1.2.1
+      - name: Chart releaser 
+        uses: stefanprodan/helm-gh-pages@v1.4.1
         with:
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
           charts_dir: ${{ inputs.chart_path }}
-          charts_repo_url: ${{ inputs.chart_url }}
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          charts_url: ${{ inputs.chart_url }}
+          linting: "off"
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR changes the `chart-releaser-action` with the stefanprodan action (`helm-gh-pages`). There are three reasons for the change:
- The `chart-releaser-action` doesn't download the helm binary, so you need to use the azure action to install `helm`.
- The dependencies are not built and downloaded when you package the chart, so you need to explicitly add each repo manually in your workflow (https://github.com/helm/chart-releaser-action/issues/6).
- Finally this action doesn't work with tags, so you only can generate releases on branches (https://github.com/helm/chart-releaser-action/issues/60) 