### PR TITLE
feat: new major version hardcoded

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -34,7 +34,7 @@ jobs:
         id: rc_tag
         uses: intelygenz/monorepo-tagger-action@v1.3.0
         with:
-          current-major: 0
+          current-major: 1
           mode: 'product'
           type: 'pre-release'
           release-branch-prefix: "release/v"


### PR DESCRIPTION
We need to move to the next major version. This feature needs to be improved/finished to not have to manual change the major version each time we need to.

If we are moving to a manual step to trigger a helm release, this major could be a param in the manual workflow