### PR TITLE
feat(tagger-action): use versions when updating versions file

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,38 +51,35 @@ jobs:
 
       - if: ${{ !inputs.component_app && !inputs.not_change_file }} 
         name: Generate a release tag for component
-        uses: intelygenz/monorepo-tagger-action@v1.3.0
+        uses: intelygenz/monorepo-tagger-action@v2.0.0
         id: release_tag_component
         with:
           mode: 'component'
           type: 'final'
           component-prefix: "${{ inputs.component }}-"
-          strip-component-from-tag: true
           update-versions-in: '[{"file": "${{ inputs.values_file }}", "property": "${{ inputs.component_helm_tag }}"}]'
         env:
           GITHUB_TOKEN: ${{ secrets.pat }}
 
       - if: ${{ inputs.not_change_file }}
         name: Generate a release tag for component and not change file
-        uses: intelygenz/monorepo-tagger-action@v1.3.0
+        uses: intelygenz/monorepo-tagger-action@v2.0.0
         id: release_tag_not_component
         with:
           mode: 'component'
           type: 'final'
           component-prefix: "${{ inputs.component }}-"
-          strip-component-from-tag: true
         env:
           GITHUB_TOKEN: ${{ secrets.pat }}
 
       - if: ${{ inputs.component_app }}
         name: Generate a release tag for component app
-        uses: intelygenz/monorepo-tagger-action@v1.3.0
+        uses: intelygenz/monorepo-tagger-action@v2.0.0
         id: release_tag_app
         with:
           mode: 'component'
           type: 'final'
           component-prefix: "${{ inputs.component }}-"
-          strip-component-from-tag: true
           update-versions-in: '[{"file": "${{ inputs.values_file }}", "property": "${{ inputs.component_helm_tag }}"}, {"file": "${{ inputs.chart_file }}", "property": "appVersion"}]'
         env:
           GITHUB_TOKEN: ${{ secrets.pat }}
@@ -108,13 +105,12 @@ jobs:
 
       - if: ${{ !inputs.component_app && !inputs.not_change_file }}
         name: Generate a fix tag for component
-        uses: intelygenz/monorepo-tagger-action@v1.3.0
+        uses: intelygenz/monorepo-tagger-action@v2.0.0
         id: fix_tag_component
         with:
           mode: 'component'
           type: 'fix'
           component-prefix: "${{ inputs.component }}-"
-          strip-component-from-tag: true
           current-tag: ${{ steps.component_version.outputs.TAG }}
           update-versions-in: '[{"file": "${{ inputs.values_file }}", "property": "${{ inputs.component_helm_tag }}"}]'
         env:
@@ -122,26 +118,24 @@ jobs:
 
       - if: ${{ inputs.not_change_file }}
         name: Generate a fix tag for component and not change file
-        uses: intelygenz/monorepo-tagger-action@v1.3.0
+        uses: intelygenz/monorepo-tagger-action@v2.0.0
         id: fix_tag_not_component
         with:
           mode: 'component'
           type: 'fix'
           component-prefix: "${{ inputs.component }}-"
-          strip-component-from-tag: true
           current-tag: ${{ steps.component_version.outputs.TAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.pat }}
 
       - if: ${{ inputs.component_app }}
         name: Generate a fix tag for component app
-        uses: intelygenz/monorepo-tagger-action@v1.3.0
+        uses: intelygenz/monorepo-tagger-action@v2.0.0
         id: fix_tag_app
         with:
           mode: 'component'
           type: 'fix'
           component-prefix: "${{ inputs.component }}-"
-          strip-component-from-tag: true
           current-tag: ${{ steps.component_version.outputs.TAG }}
           update-versions-in: '[{"file": "${{ inputs.values_file }}", "property": "${{ inputs.component_helm_tag }}"}, {"file": "${{ inputs.chart_file }}", "property": "appVersion"}]'
         env:

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Generate a pre-release
         id: rc_tag
-        uses: intelygenz/monorepo-tagger-action@v1.3.0
+        uses: intelygenz/monorepo-tagger-action@v2.0.0
         with:
           current-major: ${{ inputs.current_major }}
           mode: 'product'
@@ -64,7 +64,7 @@ jobs:
 
       - name: Generate a fix tag
         id: fix_tag
-        uses: intelygenz/monorepo-tagger-action@v1.3.0
+        uses: intelygenz/monorepo-tagger-action@v2.0.0
         with:
           mode: 'product'
           type: 'fix'

--- a/.github/workflows/new-release.yaml
+++ b/.github/workflows/new-release.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Generate a new release branch
         id: release_branch
-        uses: intelygenz/monorepo-tagger-action@v1.3.0
+        uses: intelygenz/monorepo-tagger-action@v2.0.0
         with:
           release-branch-prefix: "release/v"
           mode: 'product'
@@ -51,7 +51,7 @@ jobs:
 
       - name: Generate a release
         id: release_tag
-        uses: intelygenz/monorepo-tagger-action@v1.3.0
+        uses: intelygenz/monorepo-tagger-action@v2.0.0
         with:
           mode: 'product'
           type: 'final'


### PR DESCRIPTION
The new tagger action version removes the `strip-component-from-tag` and adds a new input param `use-tag-in-versions-file`.
By default the versions files are updated with the new generated version of the component.