### PR TITLE
fix(release-name): force semver release name

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -103,6 +103,7 @@ jobs:
               --owner "$owner" \
               --git-repo "$repo" \
               --token "${{ secrets.GITHUB_TOKEN }}" \
+              --release-name-template "v{{ .Version }}" \
               --commit "$(git rev-parse HEAD)" \
               --skip-existing
           # Update index and push to github pages


### PR DESCRIPTION
Releases to GitHub must be semver if you want to have them properly sorted.

https://github.com/github/feedback/discussions/8226

Force the release name by overwritting the default option:
`--release-name-template "{{ .Name }}-{{ .Version }}"` with `--release-name-template "v{ .Version }}"`

Its important to note that we are changing the releases names in github, but the chart release are still created with the default values `"{{ .Name }}-{{ .Version }}"` and updated into the repository index. The CR documentation can be located here: https://github.com/helm/chart-releaser#create-github-releases-from-helm-chart-packages

For example, a release with name `v1.2.3` will point the the chart `kdl-app-1.2.3`