### PR TITLE
fix: Update tagger action version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - if: ${{ !inputs.component_app && !inputs.not_change_file }} 
         name: Generate a release tag for component
-        uses: intelygenz/monorepo-tagger-action@v2.0.2
+        uses: intelygenz/monorepo-tagger-action@v2.0.3
         id: release_tag_component
         with:
           mode: 'component'
@@ -63,7 +63,7 @@ jobs:
 
       - if: ${{ inputs.not_change_file }}
         name: Generate a release tag for component and not change file
-        uses: intelygenz/monorepo-tagger-action@v2.0.2
+        uses: intelygenz/monorepo-tagger-action@v2.0.3
         id: release_tag_not_component
         with:
           mode: 'component'
@@ -74,7 +74,7 @@ jobs:
 
       - if: ${{ inputs.component_app }}
         name: Generate a release tag for component app
-        uses: intelygenz/monorepo-tagger-action@v2.0.2
+        uses: intelygenz/monorepo-tagger-action@v2.0.3
         id: release_tag_app
         with:
           mode: 'component'
@@ -105,7 +105,7 @@ jobs:
 
       - if: ${{ !inputs.component_app && !inputs.not_change_file }}
         name: Generate a fix tag for component
-        uses: intelygenz/monorepo-tagger-action@v2.0.2
+        uses: intelygenz/monorepo-tagger-action@v2.0.3
         id: fix_tag_component
         with:
           mode: 'component'
@@ -118,7 +118,7 @@ jobs:
 
       - if: ${{ inputs.not_change_file }}
         name: Generate a fix tag for component and not change file
-        uses: intelygenz/monorepo-tagger-action@v2.0.2
+        uses: intelygenz/monorepo-tagger-action@v2.0.3
         id: fix_tag_not_component
         with:
           mode: 'component'
@@ -130,7 +130,7 @@ jobs:
 
       - if: ${{ inputs.component_app }}
         name: Generate a fix tag for component app
-        uses: intelygenz/monorepo-tagger-action@v2.0.2
+        uses: intelygenz/monorepo-tagger-action@v2.0.3
         id: fix_tag_app
         with:
           mode: 'component'

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Generate a pre-release
         id: rc_tag
-        uses: intelygenz/monorepo-tagger-action@v2.0.2
+        uses: intelygenz/monorepo-tagger-action@v2.0.3
         with:
           current-major: ${{ inputs.current_major }}
           mode: 'product'
@@ -64,7 +64,7 @@ jobs:
 
       - name: Generate a fix tag
         id: fix_tag
-        uses: intelygenz/monorepo-tagger-action@v2.0.2
+        uses: intelygenz/monorepo-tagger-action@v2.0.3
         with:
           mode: 'product'
           type: 'fix'

--- a/.github/workflows/new-release.yaml
+++ b/.github/workflows/new-release.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Generate a new release branch
         id: release_branch
-        uses: intelygenz/monorepo-tagger-action@v2.0.2
+        uses: intelygenz/monorepo-tagger-action@v2.0.3
         with:
           release-branch-prefix: "release/v"
           mode: 'product'
@@ -51,7 +51,7 @@ jobs:
 
       - name: Generate a release
         id: release_tag
-        uses: intelygenz/monorepo-tagger-action@v2.0.2
+        uses: intelygenz/monorepo-tagger-action@v2.0.3
         with:
           mode: 'product'
           type: 'final'


### PR DESCRIPTION
Update **monorepo-tagger-action** version to `v2.0.3` because it fixes Semver regex parsing