### PR TITLE
fix(workflow): remove set-output deprecated option

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
       tag: ${{ steps.release_tag_component.outputs.tag }}${{ steps.release_tag_app.outputs.tag }}${{ steps.release_tag_not_component.outputs.tag }}
       version: ${{ steps.release_tag_component.outputs.version }}${{ steps.release_tag_app.outputs.version }}${{ steps.release_tag_not_component.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.pat }}
 
@@ -93,7 +93,7 @@ jobs:
       tag: ${{ steps.fix_tag_component.outputs.tag }}${{ steps.fix_tag_app.outputs.tag }}${{ steps.fix_tag_not_component.outputs.tag }}
       version: ${{ steps.fix_tag_component.outputs.version }}${{ steps.fix_tag_app.outputs.version }}${{ steps.fix_tag_not_component.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.pat }}
 
@@ -150,32 +150,32 @@ jobs:
     needs: [create-release-tag, create-fix-tag]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: "${{needs.create-release-tag.outputs.tag}}${{needs.create-fix-tag.outputs.tag}}" 
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: ${{ runner.os }}-buildx-
 
       - name: Login to DockerHub Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.docker_username }}
           password: ${{ secrets.docker_token }}
 
       - name: Push to Docker Hub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./${{ inputs.component_path }}
           file: ./${{ inputs.component_path }}/Dockerfile

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,7 +102,7 @@ jobs:
         id: component_version
         run: |
           TAG=`yq r ${{ inputs.values_file }} '${{ inputs.component_helm_tag }}'`
-          echo ::set-output name=TAG::${TAG##*:}
+          echo "TAG=${TAG##*:}" >> $GITHUB_OUTPUT
           echo Component version in release branch is ${TAG##*:}
 
       - if: ${{ !inputs.component_app && !inputs.not_change_file }}

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -7,11 +7,11 @@ jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       tag: ${{ steps.rc_tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.pat }}
 
@@ -57,7 +57,7 @@ jobs:
     outputs:
       tag: ${{ steps.fix_tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.pat }}
           ref: ${{ github.event.workflow_run.head_branch }}
@@ -74,7 +74,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.pat }}
 
-      - uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
 
       - uses: chrisdickinson/setup-yq@latest
 

--- a/.github/workflows/lint-dockerfile.yaml
+++ b/.github/workflows/lint-dockerfile.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: hadolint/hadolint-action@v1.6.0
+      - uses: hadolint/hadolint-action@v2.1.0
         with:
           dockerfile: ./${{ inputs.component_path }}/Dockerfile
           format: tty

--- a/.github/workflows/new-release.yaml
+++ b/.github/workflows/new-release.yaml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       tag: ${{ steps.release_branch.outputs.tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.pat }}
 
@@ -43,7 +43,7 @@ jobs:
     outputs:
       tag: ${{ steps.release_tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.pat }}
           ref: ${{ needs.create-release-branch.outputs.tag }}
@@ -60,7 +60,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.pat }}
       
-      - uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
 
       - uses: chrisdickinson/setup-yq@latest
 

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -15,10 +15,10 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
 


### PR DESCRIPTION
Using the new way of outputs for GA and removing set-output (deprecated command):
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/